### PR TITLE
PE-854: Adds `ssh` and `net-tools` packages to the docker image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,9 @@ RUN apt-get install --no-install-recommends -y \
     jq \
     parallel \
     sudo \
-    vim
+    vim \
+    ssh \
+    net-tools
 
 # Clear apt cache
 RUN apt-get clean -y


### PR DESCRIPTION
To facilitate the development of tests by using an SSH plugin for VSCODE to open a remote workspace (i.e. CLI repo at the docker host itself)