### PR TITLE
bug(BATS): Fix weird BATS ENV missing

### DIFF
--- a/scripts/.bashrc_patch
+++ b/scripts/.bashrc_patch
@@ -1,4 +1,6 @@
 export ENTITIES="/home/node/ardrive-cli/.bats/entities.sh"
+#Set on Dockerfile as well
+export PATH="/home/node/packages/node_modules/.bin:${PATH}"
 
 if [[ -z "${NO_SETUP}" ]] && [[ ! -f "/home/node/ardrive-cli/package.json" ]]; then
     source /home/node/entry.sh


### PR DESCRIPTION
Quick fix due to an issue keeping ENV variables after reloading shell.