### PR TITLE
feat(docker image deps): locks the bats version PE-1930

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "bats-on-steroids",
-    "version": "1.0.0",
-    "description": "This file is use for dependency management only and will never be used on the end Docker image",
-    "private": "true",
-    "devDependencies": {
-        "bats": "^1.5.0",
-        "bats-support": "git+https://github.com/bats-core/bats-support",
-        "bats-assert": "git+https://github.com/bats-core/bats-assert",
-        "bats-file": "git+https://github.com/bats-core/bats-file"
-    }
+  "name": "bats-on-steroids",
+  "version": "1.0.1",
+  "description": "This file is use for dependency management only and will never be used on the end Docker image",
+  "private": "true",
+  "devDependencies": {
+    "bats": "1.7.0",
+    "bats-support": "git+https://github.com/bats-core/bats-support",
+    "bats-assert": "git+https://github.com/bats-core/bats-assert",
+    "bats-file": "git+https://github.com/bats-core/bats-file"
+  }
 }


### PR DESCRIPTION
Locks the `bats` version to v1.7.0 to have a deterministic testing environment.